### PR TITLE
Kits, splitters, new encrypt and decrypt, more

### DIFF
--- a/nkms/characters.py
+++ b/nkms/characters.py
@@ -587,17 +587,15 @@ class Ursula(Character):
         """
         from nkms.policy.models import Contract  # Avoid circular import
         hrac = binascii.unhexlify(hrac_as_hex)
+        policy_message_kit = MessageKit.from_bytes(request.body)
+        # group_payload_splitter = BytestringSplitter(PublicKey)
+        # policy_payload_splitter = BytestringSplitter((KFrag, KFRAG_LENGTH))
 
-        group_payload_splitter = BytestringSplitter(PublicKey)
-        policy_payload_splitter = BytestringSplitter((KFrag, KFRAG_LENGTH))
-
-        alice_pubkey_sig, payload_encrypted_for_ursula =\
-            group_payload_splitter(request.body, msgpack_remainder=True)
-        alice = Alice.from_public_keys((SigningPower, alice_pubkey_sig))
+        alice = Alice.from_public_keys((SigningPower, policy_message_kit.alice_pubkey))
         self.learn_about_actor(alice)
 
         verified, cleartext = self.verify_from(
-                alice, payload_encrypted_for_ursula,
+                alice, policy_message_kit,
                 decrypt=True, signature_is_on_cleartext=True)
 
         if not verified:

--- a/nkms/characters.py
+++ b/nkms/characters.py
@@ -150,7 +150,7 @@ class Character(object):
     def learn_about_actor(self, actor):
         self._actor_mapping[actor.id()] = actor
 
-    def encrypt_for(self, recipient: "Character", cleartext: bytes,
+    def encrypt_for(self, recipient: "Character", plaintext: bytes,
                     sign: bool=True, sign_cleartext=True) -> tuple:
         """
         Looks up recipient actor, finds that actor's pubkey_enc on our keyring,
@@ -158,7 +158,7 @@ class Character(object):
 
         :param recipient: The character whose public key will be used to encrypt
             cleartext.
-        :param cleartext: The secret to be encrypted.
+        :param plaintext: The secret to be encrypted.
         :param sign: Whether or not to sign the message.
         :param sign_cleartext: When signing, the cleartext is signed if this is
             True,  Otherwise, the resulting ciphertext is signed.
@@ -170,19 +170,19 @@ class Character(object):
 
         if sign:
             if sign_cleartext:
-                signature = self.seal(cleartext)
-                ciphertext = self._crypto_power.encrypt_for(
-                        actor.public_key(EncryptingPower), signature + cleartext)
+                signature = self.seal(plaintext)
+                message_kit = self._crypto_power.encrypt_for(
+                        actor.public_key(EncryptingPower), signature + plaintext)
             else:
-                ciphertext = self._crypto_power.encrypt_for(
-                        actor.public_key(EncryptingPower), cleartext)
-                signature = self.seal(ciphertext)
+                message_kit = self._crypto_power.encrypt_for(
+                        actor.public_key(EncryptingPower), plaintext)
+                signature = self.seal(message_kit)
         else:
             signature = NOT_SIGNED
-            ciphertext = self._crypto_power.encrypt_for(
-                            actor.public_key(EncryptingPower), cleartext)
+            message_kit = self._crypto_power.encrypt_for(
+                            actor.public_key(EncryptingPower), plaintext)
 
-        return ciphertext, signature
+        return message_kit, signature
 
     def verify_from(self,
             actor_whom_sender_claims_to_be: "Character", message: bytes,

--- a/nkms/characters.py
+++ b/nkms/characters.py
@@ -98,7 +98,7 @@ class Character(object):
         """raised when an action appears to amount to malicious conduct."""
 
     @classmethod
-    def from_public_keys(cls, *powers_and_key_bytes):
+    def from_public_keys(cls, *powers_and_keys):
         """
         Sometimes we discover a Character and, at the same moment, learn one or
         more of their public keys. Here, we take a collection of tuples
@@ -111,8 +111,13 @@ class Character(object):
         """
         crypto_power = CryptoPower()
 
-        for power_up, public_key_bytes in powers_and_key_bytes:
-            crypto_power.consume_power_up(power_up(pubkey_bytes=public_key_bytes))
+        for power_up, public_key in powers_and_keys:
+            try:
+                umbral_key = UmbralPublicKey(public_key)
+            except TypeError:
+                umbral_key = public_key
+
+            crypto_power.consume_power_up(power_up(pubkey=umbral_key))
 
         return cls(is_me=False, crypto_power=crypto_power)
 

--- a/nkms/crypto/kits.py
+++ b/nkms/crypto/kits.py
@@ -1,12 +1,28 @@
+from nkms.crypto.splitters import key_splitter, capsule_splitter
 from umbral import umbral
 
 
-class MessageKit:
+class CryptoKit:
+    return_remainder_when_splitting = True
 
-    def __init__(self, ciphertext, capsule, alice_pubkey=None):
+    @classmethod
+    def split_bytes(cls, some_bytes):
+        return cls.splitter(some_bytes,
+                            return_remainder=cls.return_remainder_when_splitting)
+
+    @classmethod
+    def from_bytes(cls, some_bytes):
+        constituents = cls.split_bytes(some_bytes)
+        return cls(*constituents)
+
+
+class MessageKit(CryptoKit):
+    splitter = capsule_splitter + key_splitter
+
+    def __init__(self, capsule, alice_pubkey, ciphertext):
         self.ciphertext = ciphertext
         self.capsule = capsule
-        self.alice_pub_key = alice_pubkey
+        self.alice_pubkey = alice_pubkey
 
     def decrypt(self, privkey):
         return umbral.decrypt(

--- a/nkms/crypto/kits.py
+++ b/nkms/crypto/kits.py
@@ -31,6 +31,12 @@ class MessageKit(CryptoKit):
             self.alice_pubkey
         )
 
+    def __bytes__(self):
+        as_bytes = bytes(self.capsule)
+        if self.alice_pubkey:
+            as_bytes += bytes(self.alice_pubkey)
+        as_bytes += self.ciphertext
+        return as_bytes
 
 class MapKit(MessageKit):
 

--- a/nkms/crypto/kits.py
+++ b/nkms/crypto/kits.py
@@ -38,8 +38,8 @@ class MessageKit(CryptoKit):
         as_bytes += self.ciphertext
         return as_bytes
 
-class MapKit(MessageKit):
 
+class MapKit(MessageKit):
     def __init__(self, ciphertext, capsule, treasure_map, alice_pubkey=None):
         super().__init__(ciphertext, capsule, alice_pubkey)
         self.treasure_map = treasure_map

--- a/nkms/crypto/powers.py
+++ b/nkms/crypto/powers.py
@@ -105,10 +105,10 @@ class CryptoPowerUp(object):
 class KeyPairBasedPower(CryptoPowerUp):
     _keypair_class = keypairs.Keypair
 
-    def __init__(self, keypair: keypairs.Keypair = None,
-                 pubkey_bytes: bytes = None,
+    def __init__(self, keypair: keypairs.Keypair=None,
+                 pubkey: UmbralPublicKey=None,
                  generate_keys_if_needed=True) -> None:
-        if keypair and pubkey_bytes:
+        if keypair and pubkey:
             raise ValueError(
                 "Pass keypair or pubkey_bytes (or neither), but not both.")
         elif keypair:
@@ -116,9 +116,13 @@ class KeyPairBasedPower(CryptoPowerUp):
         else:
             # They didn't pass a keypair; we'll make one with the bytes (if any)
             # they provided.
+            if pubkey:
+                key_to_pass_to_keypair = pubkey
+            else:
+                # They didn't even pass pubkey_bytes.  We'll generate a keypair.
+                key_to_pass_to_keypair = UmbralPrivateKey.gen_key()
             self.keypair = self._keypair_class(
-                UmbralPublicKey.from_bytes(pubkey_bytes),
-                generate_keys_if_needed=generate_keys_if_needed)
+                umbral_key=key_to_pass_to_keypair)
 
 
 class SigningPower(KeyPairBasedPower):

--- a/nkms/crypto/powers.py
+++ b/nkms/crypto/powers.py
@@ -233,49 +233,14 @@ class EncryptingPower(KeyPairBasedPower):
             keys.append((path_priv, path_pub))
         return keys
 
-    def encrypt(
-            self,
-            data: bytes,
-            pubkey: bytes = None
-    ) -> Tuple[bytes, bytes]:
-        """
-        Encrypts data with Public key encryption
-
-        :param data: Data to encrypt
-        :param pubkey: publc key to encrypt for
-
-        :return: (Encrypted Key, Encrypted data)
-        """
-        pubkey = pubkey or self.pub_key
-
-        key, enc_key = API.ecies_encapsulate(pubkey)
-        enc_data = API.symm_encrypt(key, data)
-
-        return (enc_data, API.elliptic_curve.serialize(enc_key.ekey))
-
     def decrypt(
             self,
-            enc_data: Tuple[bytes, bytes],
-            privkey: bytes = None
+            message_kit: MessageKit,
     ) -> bytes:
-        """
-        Decrypts data using ECIES PKE. If no `privkey` is provided, it uses
-        `self.priv_key`.
+        cleartext = umbral.umbral.decrypt(message_kit.capsule, self.keypair.privkey,
+                              message_kit.ciphertext, message_kit.alice_pubkey)
 
-        :param enc_data: Tuple: (encrypted data, ECIES encapsulated key)
-        :param privkey: Private key to decapsulate with
-
-        :return: Decrypted data
-        """
-        privkey = privkey or self.priv_key
-        ciphertext, enc_key = enc_data
-
-        enc_key = API.elliptic_curve.deserialize(API.PRE.ecgroup, enc_key)
-        enc_key = API.umbral.EncryptedKey(ekey=enc_key, re_id=None)
-
-        dec_key = API.ecies_decapsulate(privkey, enc_key)
-
-        return API.symm_decrypt(dec_key, ciphertext)
+        return cleartext
 
     def public_key(self):
         return self.keypair.pubkey

--- a/nkms/crypto/powers.py
+++ b/nkms/crypto/powers.py
@@ -89,13 +89,10 @@ class CryptoPower(object):
         except KeyError:
             raise NoEncryptingPower
 
-    def encrypt_for(self, pubkey, cleartext):
-        try:
-            encrypting_power = self._power_ups[EncryptingPower]
-            ciphertext = encrypting_power.encrypt(cleartext, bytes(pubkey))
-            return ciphertext
-        except KeyError:
-            raise NoEncryptingPower
+    def encrypt_for(self, pubkey, plaintext):
+        ciphertext, capsule = umbral.umbral.encrypt(pubkey, plaintext)
+        return MessageKit(ciphertext=ciphertext, capsule=capsule,
+                          alice_pubkey=pubkey)
 
 
 class CryptoPowerUp(object):

--- a/nkms/crypto/powers.py
+++ b/nkms/crypto/powers.py
@@ -1,11 +1,12 @@
 import inspect
 from typing import Iterable, List, Tuple
 
+import umbral
 from nkms.crypto import api as API
-from nkms.crypto.signature import Signature
+from nkms.crypto.kits import MessageKit
 from nkms.keystore import keypairs
 from nkms.keystore.keypairs import SigningKeypair, EncryptingKeypair
-from umbral.keys import UmbralPublicKey
+from umbral.keys import UmbralPublicKey, UmbralPrivateKey
 
 
 class PowerUpError(TypeError):
@@ -22,7 +23,6 @@ class NoEncryptingPower(PowerUpError):
 
 class CryptoPower(object):
     def __init__(self, power_ups=None, generate_keys_if_needed=False):
-
         self._power_ups = {}
         # TODO: The keys here will actually be IDs for looking up in a KeyStore.
         self.public_keys = {}

--- a/nkms/crypto/signature.py
+++ b/nkms/crypto/signature.py
@@ -16,7 +16,7 @@ class Signature(object):
     def __repr__(self):
         return "ECDSA Signature: {}".format(bytes(self).hex()[:15])
 
-    def verify(self, message: bytes, pubkey: UmbralPublicKey) -> bool:
+    def verify(self, message: bytes, pubkey: UmbralPublicKey=None) -> bool:
         """
         Verifies that a message's signature was valid.
 
@@ -53,4 +53,6 @@ class Signature(object):
 
     def __add__(self, other):
         return bytes(self) + other
-    __radd__ = __add__
+
+    def __radd__(self, other):
+        return other + bytes(self)

--- a/nkms/crypto/splitters.py
+++ b/nkms/crypto/splitters.py
@@ -1,0 +1,7 @@
+from nkms.crypto.constants import PUBLIC_KEY_LENGTH, CAPSULE_LENGTH
+from nkms.crypto.utils import BytestringSplitter
+from umbral.keys import UmbralPublicKey
+from umbral.umbral import Capsule
+
+key_splitter = BytestringSplitter((UmbralPublicKey, PUBLIC_KEY_LENGTH, {"as_b64": False}))
+capsule_splitter = BytestringSplitter((Capsule, CAPSULE_LENGTH))

--- a/nkms/crypto/utils.py
+++ b/nkms/crypto/utils.py
@@ -11,24 +11,26 @@ class BytestringSplitter(object):
     def __call__(self, splittable, return_remainder=False, msgpack_remainder=False):
         if not any((return_remainder, msgpack_remainder)) and len(self) != len(splittable):
             raise ValueError(
-                "Wrong number of bytes to constitute message types {} - need {}, got {} \n Did you mean to return the remainder?".format(
+                """"Wrong number of bytes to constitute message types {} - 
+                need {}, got {} \n Did you mean to return the remainder?""".format(
                     self.message_types, len(self), len(splittable)))
         if len(self) > len(splittable):
             raise ValueError(
-                "Not enough bytes to constitute message types {} - need {}, got {}".format(self.message_types,
-                                                                                           len(self),
-                                                                                           len(splittable)))
+                """Not enough bytes to constitute
+                message types {} - need {}, got {}""".format(self.message_types,
+                                                           len(self),
+                                                           len(splittable)))
         cursor = 0
         message_objects = []
 
         for message_type in self.message_types:
-            message_class, message_length = self.get_message_meta(message_type)
+            message_class, message_length, kwargs = self.get_message_meta(message_type)
             expected_end_of_object_bytes = cursor + message_length
             bytes_for_this_object = splittable[cursor:expected_end_of_object_bytes]
             try:
-                message = message_class.from_bytes(bytes_for_this_object)
+                message = message_class.from_bytes(bytes_for_this_object, **kwargs)
             except AttributeError:
-                message = message_class(bytes_for_this_object)
+                message = message_class(bytes_for_this_object, **kwargs)
 
             message_objects.append(message)
             cursor = expected_end_of_object_bytes

--- a/nkms/keystore/keystore.py
+++ b/nkms/keystore/keystore.py
@@ -1,10 +1,11 @@
-from nkms.crypto.constants import KFRAG_LENGTH
-from nkms.keystore.db.models import Key, PolicyContract, Workorder
-from nkms.crypto.utils import BytestringSplitter
-from nkms.crypto.signature import Signature
-from sqlalchemy.orm import sessionmaker
 from typing import Union
 
+from sqlalchemy.orm import sessionmaker
+
+from nkms.crypto.constants import KFRAG_LENGTH
+from nkms.crypto.signature import Signature
+from nkms.crypto.utils import BytestringSplitter
+from nkms.keystore.db.models import Key, PolicyContract, Workorder
 from umbral.fragments import KFrag
 from umbral.keys import UmbralPublicKey
 from . import keypairs
@@ -32,8 +33,9 @@ class KeyStore(object):
         self.session = sessionmaker(bind=sqlalchemy_engine)()
 
     def add_key(self,
-                keypair: Union[keypairs.EncryptingKeypair
+                keypair: Union[keypairs.EncryptingKeypair,
                                keypairs.SigningKeypair]) -> Key:
+
         """
         :param keypair: Keypair object to store in the keystore.
 
@@ -49,82 +51,56 @@ class KeyStore(object):
         self.session.commit()
         return new_key
 
-    def get_key(self, fingerprint: bytes) -> Union[keypairs.EncryptingKeypair,
-                                                   keypairs.SigningKeypair]:
-        """
-        Returns a key from the KeyStore.
 
-        :param fingerprint: Fingerprint, in bytes, of key to return
+def get_key(self, fingerprint: bytes) -> Union[keypairs.EncryptingKeypair,
+                                               keypairs.SigningKeypair]:
+    """
+    Returns a key from the KeyStore.
 
-        :return: Keypair of the returned key.
-        """
-        key = self.session.query(Key).filter_by(fingerprint=fingerprint).first()
-        if not key:
-            raise NotFound(
-                    "No key with fingerprint {} found.".format(fingerprint))
-        if key.is_signing:
-            pubkey = UmbralPublicKey(key.key_data, as_b64=True)
-            return keypairs.SigningKeypair(pubkey)
+    :param fingerprint: Fingerprint, in bytes, of key to return
 
-    def del_key(self, fingerprint: bytes):
-        """
-        Deletes a key from the KeyStore.
+    :return: Keypair of the returned key.
+    """
+    key = self.session.query(Key).filter_by(fingerprint=fingerprint).first()
+    if not key:
+        raise NotFound(
+            "No key with fingerprint {} found.".format(fingerprint))
+    if key.is_signing:
+        pubkey = UmbralPublicKey(key.key_data, as_b64=True)
+        return keypairs.SigningKeypair(pubkey)
 
-        :param fingerprint: Fingerprint of key to delete
-        """
-        self.session.query(Key).filter_by(fingerprint=fingerprint).delete()
-        self.session.commit()
 
-    def add_policy_contract(self, expiration, deposit, hrac,
-                            alice_pubkey_sig, alice_pubkey_enc,
-                            bob_pubkey_sig, alice_signature) -> PolicyContract:
-        """
-        Creates a PolicyContract to the Keystore.
-        
-        :return: The newly added PolicyContract object
-        """
-        # TODO: This can be optimized to one commit/write.
-        alice_pubkey_sig = self.add_key(alice_pubkey_sig)
-        alice_pubkey_enc = self.add_key(alice_pubkey_enc)
-        bob_pubkey_sig = self.add_key(bob_pubkey_sig)
+def del_key(self, fingerprint: bytes):
+    """
+    Deletes a key from the KeyStore.
 
-        new_policy_contract = PolicyContract(
-                expiration, deposit, hrac, alice_pubkey_sig.id,
-                alice_pubkey_enc.id, bob_pubkey_sig.id, alice_signature
-        )
+    :param fingerprint: Fingerprint of key to delete
+    """
+    self.session.query(Key).filter_by(fingerprint=fingerprint).delete()
+    self.session.commit()
 
-        self.session.add(new_policy_contract)
 
-        return new_policy_contract
+def add_policy_contract(self, expiration, deposit, hrac,
+                        alice_pubkey_sig, alice_pubkey_enc,
+                        bob_pubkey_sig, alice_signature) -> PolicyContract:
+    """
+    Creates a PolicyContract to the Keystore.
 
-    def get_policy_contract(self, hrac: bytes) -> PolicyContract:
-        """
-        Returns the PolicyContract by its HRAC.
+    :return: The newly added PolicyContract object
+    """
+    # TODO: This can be optimized to one commit/write.
+    alice_pubkey_sig = self.add_key(alice_pubkey_sig)
+    alice_pubkey_enc = self.add_key(alice_pubkey_enc)
+    bob_pubkey_sig = self.add_key(bob_pubkey_sig)
 
-        :return: The PolicyContract object
-        """
-        policy_contract = self.session.query(PolicyContract).filter_by(hrac=hrac).first()
-        if not policy_contract:
-            raise NotFound("No PolicyContract with {} HRAC found.".format(hrac))
-        return policy_contract
+    new_policy_contract = PolicyContract(
+        expiration, deposit, hrac, alice_pubkey_sig.id,
+        alice_pubkey_enc.id, bob_pubkey_sig.id, alice_signature
+    )
 
-    def del_policy_contract(self, hrac: bytes):
-        """
-        Deletes a PolicyContract from the Keystore.
-        """
-        self.session.query(PolicyContract).filter_by(hrac=hrac).delete()
-        self.session.commit()
+    self.session.add(new_policy_contract)
 
-    def add_workorder(self, bob_pubkey_sig, bob_signature, hrac) -> Workorder:
-        """
-        Adds a Workorder to the keystore.
-        """
-        bob_pubkey_sig = self.add_key(bob_pubkey_sig)
-        new_workorder = Workorder(bob_pubkey_sig.id, bob_signature, hrac)
-
-        self.session.add(new_workorder)
-        self.session.commit()
-        return new_workorder
+    return new_policy_contract
 
     def get_workorders(self, hrac: bytes) -> Workorder:
         """

--- a/nkms/network/protocols.py
+++ b/nkms/network/protocols.py
@@ -1,6 +1,7 @@
 from kademlia.node import Node
 from kademlia.protocol import KademliaProtocol
 from kademlia.utils import digest
+
 from nkms.crypto.api import keccak_digest
 from nkms.crypto.constants import PUBLIC_KEY_LENGTH, KECCAK_DIGEST_LENGTH
 from nkms.crypto.signature import Signature

--- a/nkms/network/protocols.py
+++ b/nkms/network/protocols.py
@@ -29,7 +29,8 @@ class NuCypherHashProtocol(KademliaProtocol):
             return True
 
     def rpc_ping(self, sender, nodeid, node_capabilities=[]):
-        source = NuCypherNode(nodeid, sender[0], sender[1], capabilities_as_strings=node_capabilities)
+        source = NuCypherNode(nodeid, sender[0], sender[1],
+                              capabilities_as_strings=node_capabilities)
         self.welcomeIfNewNode(source)
         return self.sourceNode.id
 
@@ -45,13 +46,17 @@ class NuCypherHashProtocol(KademliaProtocol):
         else:
             return NODE_HAS_NO_STORAGE, False
 
-    def determine_legality_of_dht_key(self, signature, sender_pubkey_sig, message, hrac, dht_key, dht_value):
-        proper_key = digest(keccak_digest(bytes(sender_pubkey_sig) + bytes(hrac)))
+    def determine_legality_of_dht_key(self, signature, sender_pubkey_sig,
+                                      message, hrac, dht_key, dht_value):
+        proper_key = digest(
+            keccak_digest(bytes(sender_pubkey_sig) + bytes(hrac)))
 
         verified = signature.verify(hrac, sender_pubkey_sig)
 
         if not verified or not proper_key == dht_key:
-            self.log.warning("Got request to store illegal k/v: {} / {}".format(dht_key, dht_value))
+            self.log.warning(
+                "Got request to store illegal k/v: {} / {}".format(dht_key,
+                                                                   dht_value))
             self.illegal_keys_seen.append(dht_key)
             return False
         else:
@@ -63,13 +68,18 @@ class NuCypherHashProtocol(KademliaProtocol):
         self.log.debug("got a store request from %s" % str(sender))
 
         if value.startswith(b"uaddr") or value.startswith(b"trmap"):
-            signature, sender_pubkey_sig, hrac, message = dht_value_splitter(value[5::], return_remainder=True)
+            signature, sender_pubkey_sig, hrac, message = dht_value_splitter(
+                value[5::], return_remainder=True)
 
             # extra_info is a hash of the policy_group.id in the case of a treasure map, or a TTL in the case
             # of an Ursula interface.  TODO: Decide whether to keep this notion and, if so, use the TTL.
-            do_store = self.determine_legality_of_dht_key(signature, sender_pubkey_sig, message, hrac, key, value)
+            do_store = self.determine_legality_of_dht_key(signature,
+                                                          sender_pubkey_sig,
+                                                          message, hrac, key,
+                                                          value)
         else:
-            self.log.info("Got request to store bad k/v: {} / {}".format(key, value))
+            self.log.info(
+                "Got request to store bad k/v: {} / {}".format(key, value))
             do_store = False
 
         if do_store:

--- a/nkms/network/protocols.py
+++ b/nkms/network/protocols.py
@@ -11,7 +11,9 @@ from nkms.network.node import NuCypherNode
 from nkms.network.routing import NuCypherRoutingTable
 from umbral.keys import UmbralPublicKey
 
-dht_value_splitter = BytestringSplitter(Signature, (UmbralPublicKey, PUBLIC_KEY_LENGTH), (bytes, KECCAK_DIGEST_LENGTH))
+dht_value_splitter = BytestringSplitter(Signature, (
+UmbralPublicKey, PUBLIC_KEY_LENGTH, {"as_b64": False}),
+                                        (bytes, KECCAK_DIGEST_LENGTH))
 
 
 class NuCypherHashProtocol(KademliaProtocol):


### PR DESCRIPTION
- Implements encrypt from pyumbral
- Moves encrypt around a bit so that Characters don't need `EncryptingPower` to use it.
- Uses `MessageKit` to handle the results of `encrypt`.
- Implements decrypt from pyumbral
- Uses new `BytestringSplitters` in many places
- Many style changes
- Many logic cleanups
- Lots and lots of other touchups.